### PR TITLE
Add additional labels

### DIFF
--- a/labels/labels.json
+++ b/labels/labels.json
@@ -28,6 +28,10 @@
     "color": "#fdcfc2"
   },
   {
+    "name": "effort: E0 minutes",
+    "color": "#a5e3be"
+  },
+  {
     "name": "effort: E1 hours",
     "color": "#a5e3be"
   },
@@ -44,11 +48,19 @@
     "color": "#a5e3be"
   },
   {
+    "name": "effort: E5 years",
+    "color": "#a5e3be"
+  },
+  {
     "name": "eval: can't reproduce",
     "color": "#c3e2f3"
   },
   {
     "name": "eval: duplicate",
+    "color": "#c3e2f3"
+  },
+  {
+    "name": "eval: needs analysis",
     "color": "#c3e2f3"
   },
   {
@@ -113,6 +125,10 @@
   },
   {
     "name": "type: feature",
+    "color": "#e3e3e3"
+  },
+  {
+    "name": "type: breaking change",
     "color": "#e3e3e3"
   },
   {


### PR DESCRIPTION
Follow-up on #41, part of #41 

@evertonfraga Can we than just add the other labels suggested along as well? It is always some kind of a daunting task to add new labels consistently to all the libraries and it would streamline this if this is bundled.

Some special note for @rumkin on reviews: reviews are often requested by team members just for some selected people, e.g. because they were involved before or one anticipates that the person has got some free time. Nevertheless of course everyone can do reviews on every PR.